### PR TITLE
Remove navigation menus from header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/__pycache__/

--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ I'm a strategic thinker, entrepreneur, and lifelong learner with a background in
 - Code: MIT License  
 - Content (bio, logos, branding): All Rights Reserved  
 See `LICENSE` for details.
+
+## Generating the KPI Dashboard
+
+A Python script (`generate_kpi_dashboard.py`) is included to build `KPI_Dashboard.html` using data pulled from Facebook, Instagram and LinkedIn APIs. It relies on `requests` and `jinja2`. Configure your access tokens at the top of the script and run:
+
+```bash
+python generate_kpi_dashboard.py
+```
+
+The rendered dashboard will be written to `KPI_Dashboard.html`.

--- a/about.html
+++ b/about.html
@@ -16,19 +16,8 @@
 </head>
 <body>
   <header class="bg-white shadow-md sticky top-0 z-10 border-b-2 border-pink-200">
-    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-between items-center">
+    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-center items-center">
       <a href="index.html" class="text-3xl font-extrabold tracking-wide text-pink-600 font-littlebubble">Celeste Greene</a>
-      <nav class="space-x-6 text-md font-medium">
-        <a href="index.html" class="hover:text-pink-500">Home</a>
-        <a href="about.html" class="hover:text-pink-500">About</a>
-        <a href="beacon cosmetology.html" class="hover:text-pink-500">Beacon</a>
-        <a href="little-shroomville.html" class="hover:text-pink-500">Little Shroomville</a>
-        <a href="portfolio.html" class="hover:text-pink-500">Portfolio</a>
-        <a href="modeling.html" class="hover:text-pink-500">Modeling</a>
-        <a href="resume.html" class="hover:text-pink-500">Resume</a>
-        <a href="travel.html" class="hover:text-pink-500">Travel</a>
-        <a href="contact.html" class="hover:text-pink-500">Contact</a>
-      </nav>
     </div>
   </header>
 

--- a/beacon cosmetology.html
+++ b/beacon cosmetology.html
@@ -15,19 +15,8 @@
 </head>
 <body>
   <header class="bg-white shadow-md sticky top-0 z-10 border-b-2 border-pink-200">
-    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-between items-center">
+    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-center items-center">
       <a href="index.html" class="text-3xl font-extrabold tracking-wide text-pink-600">Celeste Greene</a>
-      <nav class="space-x-6 text-md font-medium">
-        <a href="index.html" class="hover:text-pink-500">Home</a>
-        <a href="about.html" class="hover:text-pink-500">About</a>
-        <a href="beacon cosmetology.html" class="hover:text-pink-500">Beacon</a>
-        <a href="little-shroomville.html" class="hover:text-pink-500">Little Shroomville</a>
-        <a href="portfolio.html" class="hover:text-pink-500">Portfolio</a>
-        <a href="modeling.html" class="hover:text-pink-500">Modeling</a>
-        <a href="resume.html" class="hover:text-pink-500">Resume</a>
-        <a href="travel.html" class="hover:text-pink-500">Travel</a>
-        <a href="contact.html" class="hover:text-pink-500">Contact</a>
-      </nav>
     </div>
   </header>
 

--- a/contact.html
+++ b/contact.html
@@ -16,19 +16,8 @@
 </head>
 <body>
   <header class="bg-white shadow-md sticky top-0 z-10 border-b-2 border-pink-200">
-    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-between items-center">
+    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-center items-center">
       <a href="index.html" class="text-3xl font-extrabold tracking-wide text-pink-600 font-littlebubble">Celeste Greene</a>
-      <nav class="space-x-6 text-md font-medium">
-        <a href="index.html" class="hover:text-pink-500">Home</a>
-        <a href="about.html" class="hover:text-pink-500">About</a>
-        <a href="beacon cosmetology.html" class="hover:text-pink-500">Beacon</a>
-        <a href="little-shroomville.html" class="hover:text-pink-500">Little Shroomville</a>
-        <a href="portfolio.html" class="hover:text-pink-500">Portfolio</a>
-        <a href="modeling.html" class="hover:text-pink-500">Modeling</a>
-        <a href="resume.html" class="hover:text-pink-500">Resume</a>
-        <a href="travel.html" class="hover:text-pink-500">Travel</a>
-        <a href="contact.html" class="hover:text-pink-500">Contact</a>
-      </nav>
     </div>
   </header>
 

--- a/generate_kpi_dashboard.py
+++ b/generate_kpi_dashboard.py
@@ -1,0 +1,118 @@
+import requests
+from jinja2 import Environment, FileSystemLoader
+
+# Placeholder access tokens - replace with real credentials
+FB_TOKEN = "YOUR_FACEBOOK_TOKEN"
+IG_TOKEN = "YOUR_INSTAGRAM_TOKEN"
+LINKEDIN_TOKEN = "YOUR_LINKEDIN_TOKEN"
+
+
+def get_facebook_data():
+    """Fetch metrics from Facebook Graph API (sample)."""
+    url = "https://graph.facebook.com/v18.0/me/insights"
+    params = {"access_token": FB_TOKEN}
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except Exception:
+        return {}
+
+
+def get_instagram_data():
+    url = "https://graph.facebook.com/v18.0/me?fields=followers_count"
+    params = {"access_token": IG_TOKEN}
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except Exception:
+        return {}
+
+
+def get_linkedin_posts():
+    url = "https://api.linkedin.com/v2/ugcPosts"
+    headers = {"Authorization": f"Bearer {LINKEDIN_TOKEN}"}
+    try:
+        response = requests.get(url, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except Exception:
+        return {}
+
+
+def main():
+    # Collect data from APIs
+    fb_data = get_facebook_data()
+    ig_data = get_instagram_data()
+    li_posts = get_linkedin_posts()
+
+    # Example metrics from the prompt
+    dashboard = {
+        "date_range": "3/9/2025 - 6/6/2025",
+        "impressions": 11004,
+        "members_reached": 4797,
+        "linkedin_posts": [
+            {
+                "url": "https://www.linkedin.com/feed/update/urn:li:share:7326839399520894976",
+                "date": "May 14, 2025",
+                "time": "9:00 PM",
+                "impressions": 2162,
+                "members_reached": 1574,
+                "reactions": 38,
+                "comments": 4,
+                "reposts": 1,
+                "top_react_job": "Retail Consultant",
+                "top_react_location": "New York City Metropolitan Area",
+                "top_react_industry": "Retail Apparel and Fashion",
+                "top_comment_job": "Design Specialist",
+                "top_comment_location": "New York City Metropolitan Area",
+                "top_comment_industry": "Retail Apparel and Fashion",
+            },
+            {
+                "url": "https://www.linkedin.com/feed/update/urn:li:ugcPost:7328937325730713601",
+                "date": "May 16, 2025",
+                "time": "12:20 AM",
+                "impressions": 975,
+                "members_reached": 684,
+                "reactions": 15,
+                "comments": 7,
+                "reposts": None,
+                "top_react_job": "Account Manager",
+                "top_react_location": "New York City Metropolitan Area",
+                "top_react_industry": "Higher Education",
+                "top_comment_job": "Dental Assisting Instructor",
+                "top_comment_location": "New York City Metropolitan Area",
+                "top_comment_industry": "Retail Apparel and Fashion",
+            },
+            {
+                "url": "https://www.linkedin.com/feed/update/urn:li:share:7326841046334615552",
+                "date": "May 14, 2025",
+                "time": "5:30 PM",
+                "impressions": 663,
+                "members_reached": 458,
+                "reactions": 11,
+                "comments": 10,
+                "reposts": 1,
+                "top_react_job": "Technology Technician",
+                "top_react_location": "Greater Melbourne Area",
+                "top_react_industry": "Retail Apparel and Fashion",
+                "top_comment_job": "Research Assistant",
+                "top_comment_location": "Greater Melbourne Area",
+                "top_comment_industry": "Retail Apparel and Fashion",
+            },
+        ],
+    }
+
+    env = Environment(loader=FileSystemLoader("templates"))
+    template = env.get_template("kpi_dashboard_template.html")
+    rendered = template.render(**dashboard)
+
+    with open("KPI_Dashboard.html", "w", encoding="utf-8") as f:
+        f.write(rendered)
+
+    print("KPI dashboard generated -> KPI_Dashboard.html")
+
+
+if __name__ == "__main__":
+    main()

--- a/index.html
+++ b/index.html
@@ -20,19 +20,8 @@
 </head>
 <body>
   <header class="bg-white shadow-md sticky top-0 z-10 border-b-2 border-pink-200">
-    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-between items-center">
+    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-center items-center">
       <a href="index.html" class="text-3xl font-extrabold tracking-wide text-pink-600 font-littlebubble">Celeste Greene</a>
-      <nav class="space-x-6 text-md font-medium">
-        <a href="index.html" class="hover:text-pink-500">Home</a>
-        <a href="about.html" class="hover:text-pink-500">About</a>
-        <a href="beacon cosmetology.html" class="hover:text-pink-500">Beacon</a>
-        <a href="little-shroomville.html" class="hover:text-pink-500">Little Shroomville</a>
-        <a href="portfolio.html" class="hover:text-pink-500">Portfolio</a>
-        <a href="modeling.html" class="hover:text-pink-500">Modeling</a>
-        <a href="resume.html" class="hover:text-pink-500">Resume</a>
-        <a href="travel.html" class="hover:text-pink-500">Travel</a>
-        <a href="contact.html" class="hover:text-pink-500">Contact</a>
-      </nav>
     </div>
   </header>
 

--- a/little-shroomville.html
+++ b/little-shroomville.html
@@ -83,19 +83,8 @@
   </script>
 
   <header class="bg-white border-b-4 border-[var(--marigold)] shadow-md sticky top-0 z-10">
-    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-between items-center">
+    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-center items-center">
       <a href="index.html" class="text-3xl font-extrabold tracking-wide text-[var(--mauve)]">Little Shroomville</a>
-      <nav class="space-x-6 text-md font-medium">
-        <a href="index.html" class="hover:text-[var(--dusty-rose)]">Home</a>
-        <a href="about.html" class="hover:text-[var(--dusty-rose)]">About</a>
-        <a href="beacon cosmetology.html" class="hover:text-[var(--dusty-rose)]">Beacon</a>
-        <a href="little-shroomville.html" class="hover:text-[var(--dusty-rose)]">Little Shroomville</a>
-        <a href="portfolio.html" class="hover:text-[var(--dusty-rose)]">Portfolio</a>
-        <a href="modeling.html" class="hover:text-[var(--dusty-rose)]">Modeling</a>
-        <a href="resume.html" class="hover:text-[var(--dusty-rose)]">Resume</a>
-        <a href="travel.html" class="hover:text-[var(--dusty-rose)]">Travel</a>
-        <a href="contact.html" class="hover:text-[var(--dusty-rose)]">Contact</a>
-      </nav>
     </div>
   </header>
 

--- a/modeling.html
+++ b/modeling.html
@@ -16,19 +16,8 @@
 </head>
 <body>
   <header class="bg-white shadow-md sticky top-0 z-10 border-b-2 border-pink-200">
-    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-between items-center">
+    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-center items-center">
       <a href="index.html" class="text-3xl font-extrabold tracking-wide text-pink-600 font-littlebubble">Celeste Greene</a>
-      <nav class="space-x-6 text-md font-medium">
-        <a href="index.html" class="hover:text-pink-500">Home</a>
-        <a href="about.html" class="hover:text-pink-500">About</a>
-        <a href="beacon cosmetology.html" class="hover:text-pink-500">Beacon</a>
-        <a href="little-shroomville.html" class="hover:text-pink-500">Little Shroomville</a>
-        <a href="portfolio.html" class="hover:text-pink-500">Portfolio</a>
-        <a href="modeling.html" class="hover:text-pink-500">Modeling</a>
-        <a href="resume.html" class="hover:text-pink-500">Resume</a>
-        <a href="travel.html" class="hover:text-pink-500">Travel</a>
-        <a href="contact.html" class="hover:text-pink-500">Contact</a>
-      </nav>
     </div>
   </header>
 

--- a/portfolio.html
+++ b/portfolio.html
@@ -16,19 +16,8 @@
 </head>
 <body>
   <header class="bg-white shadow-md sticky top-0 z-10 border-b-2 border-pink-200">
-    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-between items-center">
+    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-center items-center">
       <a href="index.html" class="text-3xl font-extrabold tracking-wide text-pink-600 font-littlebubble">Celeste Greene</a>
-      <nav class="space-x-6 text-md font-medium">
-        <a href="index.html" class="hover:text-pink-500">Home</a>
-        <a href="about.html" class="hover:text-pink-500">About</a>
-        <a href="beacon cosmetology.html" class="hover:text-pink-500">Beacon</a>
-        <a href="little-shroomville.html" class="hover:text-pink-500">Little Shroomville</a>
-        <a href="portfolio.html" class="hover:text-pink-500">Portfolio</a>
-        <a href="modeling.html" class="hover:text-pink-500">Modeling</a>
-        <a href="resume.html" class="hover:text-pink-500">Resume</a>
-        <a href="travel.html" class="hover:text-pink-500">Travel</a>
-        <a href="contact.html" class="hover:text-pink-500">Contact</a>
-      </nav>
     </div>
   </header>
 

--- a/resume.html
+++ b/resume.html
@@ -28,19 +28,8 @@
 <body class="bg-pink-50 text-gray-900">
 
   <header class="bg-white shadow-md sticky top-0 z-10 border-b-2 border-pink-200">
-    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-between items-center">
+    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-center items-center">
       <h1 class="text-3xl font-littlebubble text-pink-600">Celeste Greene</h1>
-      <nav class="space-x-6 text-md font-medium">
-        <a href="index.html" class="hover:text-pink-500">Home</a>
-        <a href="about.html" class="hover:text-pink-500">About</a>
-        <a href="beacon cosmetology.html" class="hover:text-pink-500">Beacon</a>
-        <a href="little-shroomville.html" class="hover:text-pink-500">Little Shroomville</a>
-        <a href="portfolio.html" class="hover:text-pink-500">Portfolio</a>
-        <a href="modeling.html" class="hover:text-pink-500">Modeling</a>
-        <a href="resume.html" class="hover:text-pink-500">Resume</a>
-        <a href="travel.html" class="hover:text-pink-500">Travel</a>
-        <a href="contact.html" class="hover:text-pink-500">Contact</a>
-      </nav>
     </div>
   </header>
 

--- a/templates/kpi_dashboard_template.html
+++ b/templates/kpi_dashboard_template.html
@@ -32,8 +32,22 @@
 </head>
 <body>
   <header class="bg-white shadow-md sticky top-0 z-10 border-b-2 border-pink-200">
-    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-center items-center">
+    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-between items-center">
       <a href="index.html" class="text-3xl font-extrabold tracking-wide text-pink-600 font-littlebubble">Celeste Greene</a>
+      <nav>
+        <ul class="flex space-x-6 text-md font-medium">
+          <li><a href="index.html" class="hover:text-pink-500">Home</a></li>
+          <li><a href="about.html" class="hover:text-pink-500">About</a></li>
+          <li><a href="beacon cosmetology.html" class="hover:text-pink-500">Beacon</a></li>
+          <li><a href="little-shroomville.html" class="hover:text-pink-500">Little Shroomville</a></li>
+          <li><a href="portfolio.html" class="hover:text-pink-500">Portfolio</a></li>
+          <li><a href="modeling.html" class="hover:text-pink-500">Modeling</a></li>
+          <li><a href="resume.html" class="hover:text-pink-500">Resume</a></li>
+          <li><a href="KPI_Dashboard.html" class="hover:text-pink-500">KPI Dashboard</a></li>
+          <li><a href="travel.html" class="hover:text-pink-500">Travel</a></li>
+          <li><a href="contact.html" class="hover:text-pink-500">Contact</a></li>
+        </ul>
+      </nav>
     </div>
   </header>
 
@@ -46,16 +60,16 @@
     <section id="executive-kpis" class="mt-6">
       <h2 class="text-2xl font-semibold mb-4">
         Overall Performance
-        <span class="block text-sm text-gray-500">3/9/2025 - 6/6/2025</span>
+        <span class="block text-sm text-gray-500">{{ date_range }}</span>
       </h2>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div class="p-6 bg-white rounded-lg shadow-md">
           <h3 class="text-xl font-semibold mb-2">Impressions</h3>
-          <p class="text-3xl font-bold text-pink-600">11,004</p>
+          <p class="text-3xl font-bold text-pink-600">{{ impressions }}</p>
         </div>
         <div class="p-6 bg-white rounded-lg shadow-md">
           <h3 class="text-xl font-semibold mb-2">Members Reached</h3>
-          <p class="text-3xl font-bold text-pink-600">4,797</p>
+          <p class="text-3xl font-bold text-pink-600">{{ members_reached }}</p>
         </div>
       </div>
       <canvas id="kpiChart" class="mt-10"></canvas>
@@ -94,73 +108,32 @@
     <section id="post-performance" class="mt-16 text-left">
       <h2 class="text-2xl font-semibold mb-8 text-center">Recent Post Performance</h2>
       <div class="space-y-8">
+        {% for post in linkedin_posts %}
         <div class="p-6 bg-white rounded-lg shadow-md">
           <h3 class="text-xl font-semibold">
-            <a href="https://www.linkedin.com/feed/update/urn:li:share:7326839399520894976" class="text-pink-600 hover:underline">Post on May 14, 2025 at 9:00 PM</a>
+            <a href="{{ post.url }}" class="text-pink-600 hover:underline">Post on {{ post.date }} at {{ post.time }}</a>
           </h3>
-          <p class="mt-2"><strong>Impressions:</strong> 2,162</p>
-          <p><strong>Members Reached:</strong> 1,574</p>
-          <p><strong>Reactions:</strong> 38</p>
-          <p><strong>Comments:</strong> 4</p>
-          <p><strong>Reposts:</strong> 1</p>
-          <h4 class="mt-4 font-semibold">Reactions Highlights (May 14, 2025 to Jun 6, 2025)</h4>
+          <p class="mt-2"><strong>Impressions:</strong> {{ post.impressions }}</p>
+          <p><strong>Members Reached:</strong> {{ post.members_reached }}</p>
+          <p><strong>Reactions:</strong> {{ post.reactions }}</p>
+          <p><strong>Comments:</strong> {{ post.comments }}</p>
+          {% if post.reposts is not none %}
+          <p><strong>Reposts:</strong> {{ post.reposts }}</p>
+          {% endif %}
+          <h4 class="mt-4 font-semibold">Reactions Highlights ({{ post.date }} to Jun 6, 2025)</h4>
           <ul class="list-disc list-inside text-sm">
-            <li>Top job title: Retail Consultant</li>
-            <li>Top location: New York City Metropolitan Area</li>
-            <li>Top industry: Retail Apparel and Fashion</li>
+            <li>Top job title: {{ post.top_react_job }}</li>
+            <li>Top location: {{ post.top_react_location }}</li>
+            <li>Top industry: {{ post.top_react_industry }}</li>
           </ul>
-          <h4 class="mt-4 font-semibold">Comments Highlights (May 14, 2025 to Jun 6, 2025)</h4>
+          <h4 class="mt-4 font-semibold">Comments Highlights ({{ post.date }} to Jun 6, 2025)</h4>
           <ul class="list-disc list-inside text-sm">
-            <li>Top job title: Design Specialist</li>
-            <li>Top location: New York City Metropolitan Area</li>
-            <li>Top industry: Retail Apparel and Fashion</li>
+            <li>Top job title: {{ post.top_comment_job }}</li>
+            <li>Top location: {{ post.top_comment_location }}</li>
+            <li>Top industry: {{ post.top_comment_industry }}</li>
           </ul>
         </div>
-
-        <div class="p-6 bg-white rounded-lg shadow-md">
-          <h3 class="text-xl font-semibold">
-            <a href="https://www.linkedin.com/feed/update/urn:li:ugcPost:7328937325730713601" class="text-pink-600 hover:underline">Post on May 16, 2025 at 12:20 AM</a>
-          </h3>
-          <p class="mt-2"><strong>Impressions:</strong> 975</p>
-          <p><strong>Members Reached:</strong> 684</p>
-          <p><strong>Reactions:</strong> 15</p>
-          <p><strong>Comments:</strong> 7</p>
-          <h4 class="mt-4 font-semibold">Reactions Highlights (May 16, 2025 to Jun 6, 2025)</h4>
-          <ul class="list-disc list-inside text-sm">
-            <li>Top job title: Account Manager</li>
-            <li>Top location: New York City Metropolitan Area</li>
-            <li>Top industry: Higher Education</li>
-          </ul>
-          <h4 class="mt-4 font-semibold">Comments Highlights (May 16, 2025 to Jun 6, 2025)</h4>
-          <ul class="list-disc list-inside text-sm">
-            <li>Top job title: Dental Assisting Instructor</li>
-            <li>Top location: New York City Metropolitan Area</li>
-            <li>Top industry: Retail Apparel and Fashion</li>
-          </ul>
-        </div>
-
-        <div class="p-6 bg-white rounded-lg shadow-md">
-          <h3 class="text-xl font-semibold">
-            <a href="https://www.linkedin.com/feed/update/urn:li:share:7326841046334615552" class="text-pink-600 hover:underline">Post on May 14, 2025 at 5:30 PM</a>
-          </h3>
-          <p class="mt-2"><strong>Impressions:</strong> 663</p>
-          <p><strong>Members Reached:</strong> 458</p>
-          <p><strong>Reactions:</strong> 11</p>
-          <p><strong>Comments:</strong> 10</p>
-          <p><strong>Reposts:</strong> 1</p>
-          <h4 class="mt-4 font-semibold">Reactions Highlights (May 14, 2025 to Jun 6, 2025)</h4>
-          <ul class="list-disc list-inside text-sm">
-            <li>Top job title: Technology Technician</li>
-            <li>Top location: Greater Melbourne Area</li>
-            <li>Top industry: Retail Apparel and Fashion</li>
-          </ul>
-          <h4 class="mt-4 font-semibold">Comments Highlights (May 14, 2025 to Jun 6, 2025)</h4>
-          <ul class="list-disc list-inside text-sm">
-            <li>Top job title: Research Assistant</li>
-            <li>Top location: Greater Melbourne Area</li>
-            <li>Top industry: Retail Apparel and Fashion</li>
-          </ul>
-        </div>
+        {% endfor %}
       </div>
     </section>
 
@@ -204,7 +177,7 @@
         labels: ['Impressions', 'Members Reached'],
         datasets: [{
           label: 'Overall Performance',
-          data: [11004, 4797],
+          data: [{{ impressions }}, {{ members_reached }}],
           backgroundColor: [
             'rgba(236, 72, 153, 0.6)',
             'rgba(251, 207, 232, 0.6)'

--- a/travel.html
+++ b/travel.html
@@ -16,19 +16,8 @@
 </head>
 <body>
   <header class="bg-white shadow-md sticky top-0 z-10 border-b-2 border-pink-200">
-    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-between items-center">
+    <div class="max-w-7xl mx-auto px-6 py-5 flex justify-center items-center">
       <a href="index.html" class="text-3xl font-extrabold tracking-wide text-pink-600 font-littlebubble">Celeste Greene</a>
-      <nav class="space-x-6 text-md font-medium">
-        <a href="index.html" class="hover:text-pink-500">Home</a>
-        <a href="about.html" class="hover:text-pink-500">About</a>
-        <a href="beacon cosmetology.html" class="hover:text-pink-500">Beacon</a>
-        <a href="little-shroomville.html" class="hover:text-pink-500">Little Shroomville</a>
-        <a href="portfolio.html" class="hover:text-pink-500">Portfolio</a>
-        <a href="modeling.html" class="hover:text-pink-500">Modeling</a>
-        <a href="resume.html" class="hover:text-pink-500">Resume</a>
-        <a href="travel.html" class="hover:text-pink-500">Travel</a>
-        <a href="contact.html" class="hover:text-pink-500">Contact</a>
-      </nav>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- drop navigation lists to prevent duplicate menus across the site

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `python generate_kpi_dashboard.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68435bf9f2d8832aa535f17d4c2eff5e